### PR TITLE
Change the install path using rvm_path instead of change rvm scripts

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,8 +20,8 @@ set -e
 
 case "$1" in
     configure)
-        # Go to rvm src folder and run installer
-        cd /usr/share/rvm/src/rvm/ && ./install
+        # Run RVM installer
+        rvm_path="/usr/share/rvm" /usr/share/rvm/src/rvm/install
 	# Run rvm requirements (just to double check)
         source /etc/profile.d/rvm.sh
         rvm requirements


### PR DESCRIPTION
Actually while generating the deb package, I run a simple script to automate the process.

After download the stable `rvm`, one of the tasks is to find and replaces all occurrences of `/usr/local/rvm` by `/usr/share/rvm`.

But there is no need of it. Just inform an env var `rvm_path` with new location while running the `rvm` install script.

This will follow KISS and the rule of use `rvm` install scripts features as much as possible. 

Tasks: 
- update the generator script to not find and replace `rvm` install path;
- update `debian/postinst` to set the `rvm_path` during install.
