### PR TITLE
Fixing dependencies (#19)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rvm (1.29.3-2) bionic; urgency=medium
+
+  * Updating depencencies for Bionic (#19)
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Tue, 10 Apr 2018 07:41:15 -0300
+
 rvm (1.29.3-1) xenial; urgency=medium
 
   * Updating RVM to 1.29.3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rvm (1.29.3-3) bionic; urgency=medium
+
+  * Updating/fixing dependencies for Bionic (#19)
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Tue, 10 Apr 2018 19:56:20 -0300
+
 rvm (1.29.3-2) bionic; urgency=medium
 
   * Updating depencencies for Bionic (#19)

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 
 Package: rvm
 Architecture: all
-Depends: ${misc:Depends}, bash, tar, curl, gnupg, patch, bzip2, ca-certificates, gawk, g++, gcc, make, libc6-dev, patch, openssl, ca-certificates, libreadline6, libreadline6-dev, zlib1g, zlib1g-dev, libssl-dev, libyaml-dev, libsqlite3-dev, sqlite3, autoconf, libgdbm-dev, libncurses5-dev, automake, libtool, bison, pkg-config, libffi-dev
+Depends: ${misc:Depends}, bash, tar, curl, gnupg, patch, bzip2, ca-certificates, gawk, g++, gcc, make, libc6-dev, patch, openssl, ca-certificates, libreadline-dev, zlib1g, zlib1g-dev, libssl-dev, libyaml-dev, libsqlite3-dev, sqlite3, autoconf, libgdbm-dev, libncurses5-dev, automake, libtool, bison, pkg-config, libffi-dev
 Provides: ruby
 Description: Ruby Version Manager (RVM)
  RVM is a command-line tool which allows you to easily install, manage, and 


### PR DESCRIPTION
Relates to #19. Trusty and Xenial have a `libreadline-dev` package too, so it'll work in both too.