### PR TITLE
Need to load rvm before creating gemsets for sudo users

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -18,24 +18,28 @@ set -e
 # the debian-policy package
 
 
+load_rvm() {
+    rvm_path="/usr/share/rvm" && cd $rvm_path/src/rvm && rvm_path="$rvm_path" ./install
+    # Load RVM if it is installed, try user then root install.
+    if [ -s "/etc/profile.d/rvm.sh" ] 
+    then
+      source "/etc/profile.d/rvm.sh"
+    elif
+      [[ -s "$rvm_path/scripts/rvm" ]]
+    then
+      source "$rvm_path/scripts/rvm"
+    elif
+      [[ -s "$HOME/.rvm/scripts/rvm" ]]
+    then
+      true ${rvm_path:="$HOME/.rvm"}
+      source "$HOME/.rvm/scripts/rvm"
+    fi
+}
+
 case "$1" in
     configure)
         # Run RVM installer
-        rvm_path="/usr/share/rvm" && cd $rvm_path/src/rvm && rvm_path="$rvm_path" ./install
-        # Load RVM if it is installed, try user then root install.
-        if [ -s "/etc/profile.d/rvm.sh" ] 
-        then
-          source "/etc/profile.d/rvm.sh"
-        elif
-          [[ -s "$rvm_path/scripts/rvm" ]]
-        then
-          source "$rvm_path/scripts/rvm"
-        elif
-          [[ -s "$HOME/.rvm/scripts/rvm" ]]
-        then
-          true ${rvm_path:="$HOME/.rvm"}
-          source "$HOME/.rvm/scripts/rvm"
-        fi
+        load_rvm
         # Add sudoers to rvm group
         users=`awk -F':' '/^sudo/{print $4}' /etc/group`
         IFS=',' read -a array <<< "$users"
@@ -44,11 +48,14 @@ case "$1" in
             usermod -a -G rvm $u
             if [ ! -f "/home/$u/.rvmrc" ]; then
                 echo "Creating local gemsets for $u"
-                su - $u -c 'rvm user gemsets'
+                su - $u -c "$0 gemsets"
             fi
         done
     ;;
-
+    gemsets)
+        load_rvm
+        rvm user gemsets
+    ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;
 


### PR DESCRIPTION
The Debian postinst script attempts to call `rvm user gemsets` within
an su command for each user who has sudo rights. This doesn't work
when those users haven't already configured rvm because
/usr/share/rvm/scripts/rvm doesn't get sources so the rvm command
isn't available within the su command. Deal with this by loading the
rvm script ourselves before invoking `rvm user gemsets`.

Fixes rvm/ubuntu_rvm#32