### PR TITLE
Fix broken keyserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ echo 'source "/etc/profile.d/rvm.sh"' >> ~/.bashrc
 Fine. First install the `rvm-installer` keys:
 
 ```terminal
-gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 ```
 
 Then run:


### PR DESCRIPTION
The keyserver `hkp://pool.sks-keyservers.net` is yielding the follow error: 

`gpg: keyserver receive failed: Server indicated a failure`

Update to active keyserver: `keyserver.ubuntu.com`